### PR TITLE
Fix WIF recovery public key

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,16 +50,18 @@ function App() {
   const recoverWallet = () => {
     try {
       let keyPair;
+      let publicKey: string;
       if (recoveryKey.startsWith('5') || recoveryKey.startsWith('K') || recoveryKey.startsWith('L')) {
         // WIF format
         keyPair = bitcoin.ECPair.fromWIF(recoveryKey, bitcoin.networks.bitcoin);
+        publicKey = keyPair.publicKey.toString('hex');
       } else {
         // Hex format
         const privateKey = Buffer.from(recoveryKey, 'hex');
         keyPair = ec.keyFromPrivate(privateKey);
+        publicKey = keyPair.getPublic().encode('hex');
       }
-      
-      const publicKey = keyPair.getPublic().encode('hex');
+
       const address = bitcoin.payments.p2pkh({ pubkey: Buffer.from(publicKey, 'hex') }).address;
 
       setActiveWallet({ address, privateKey: recoveryKey, publicKey });


### PR DESCRIPTION
## Summary
- fix wallet recovery to read the public key correctly when recovering from WIF

## Testing
- `npm run build`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_b_684ec15eb5188326921a71022ec9f218