### PR TITLE
Add buffer alias for build

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "lucide-react": "^0.344.0",
     "npmp": "^0.1.1",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "buffer": "^6.0.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Wallet, Send, History, Key, Coins, ArrowRight, Plus, Trash2, Download, 
 import * as bitcoin from 'bitcoinjs-lib';
 import { ec as EC } from 'elliptic';
 import axios from 'axios';
+import { Buffer } from 'buffer';
 
 const ec = new EC('secp256k1');
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,17 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+// Use the Buffer polyfill when bundling for the browser
+const alias = {
+  buffer: 'buffer/',
+};
+
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias,
+  },
   // Use relative paths so the build works when opened from the local filesystem
   base: './',
 });


### PR DESCRIPTION
## Summary
- configure Vite to alias the `buffer` polyfill

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: Could not load buffer/)*

------
https://chatgpt.com/codex/tasks/task_b_684ec15f63848326a10855f46ec552a3